### PR TITLE
Proposed v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added 
+
+- Support for sigv4 `service` attributes beyond "s3" (e.g. "execute-api") in `AwsSign` struct
+- Support for "body" attribute beyond "s3" in `AwsSign` struct
+- More documentation
+
+### Changed
+
+- Upgrage Rust Edition to 2021
+- Upgrade dependencies
+- License from MIT to BSD 2-Clause (like MIT, but "don't blame me if things go wrong")
+
+## [0.1.1] - 2019-12-30
+
+- First working version with a README: https://crates.io/crates/aws-sign-v4/0.1.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.0"
 description = "Generate AWS Signature 4 headers easily"
 repository = "https://github.com/psnszsn/aws-sign-v4"
 keywords = ["AWS", "Signature"]
-license = "MIT"
+license = "BSD 2-Clause"
 readme = "README.md"
 authors = ["Vlad Pănăzan <brgdvz@gmail.com>", "Ken Shih <ken.shih@gmail.com>"]
 edition = "2021"
@@ -18,7 +18,3 @@ hex = "0.4.3"
 ring = "0.16.20"
 http = "0.2.8"
 sha256 = "1.1.1"
-
-# [dev-dependencies]
-# reqwest = "0.10.0"
-# tokio = { version = "0.2", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,16 +7,16 @@ keywords = ["AWS", "Signature"]
 license = "MIT"
 readme = "README.md"
 authors = ["Vlad Pănăzan <brgdvz@gmail.com>", "Ken Shih <ken.shih@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono = "0.4.10"
-url = "2.1.0"
-hex = "0.4.0"
-ring = "0.16.9"
-http = "0.2.0"
+chrono = "0.4.23"
+url = "2.3.1"
+hex = "0.4.3"
+ring = "0.16.20"
+http = "0.2.8"
 sha256 = "1.1.1"
 
 # [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "aws-sign-v4"
-version = "0.1.1"
+version = "0.2.0"
 description = "Generate AWS Signature 4 headers easily"
 repository = "https://github.com/psnszsn/aws-sign-v4"
 keywords = ["AWS", "Signature"]
 license = "MIT"
 readme = "README.md"
-authors = ["Vlad Pănăzan <brgdvz@gmail.com>"]
+authors = ["Vlad Pănăzan <brgdvz@gmail.com>", "Ken Shih <ken.shih@gmail.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -17,7 +17,8 @@ url = "2.1.0"
 hex = "0.4.0"
 ring = "0.16.9"
 http = "0.2.0"
+sha256 = "1.1.1"
 
-[dev-dependencies]
-reqwest = "0.10.0"
-tokio = { version = "0.2", features = ["full"] }
+# [dev-dependencies]
+# reqwest = "0.10.0"
+# tokio = { version = "0.2", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # aws-sign-v4
 [![Crates.io](https://img.shields.io/crates/v/aws-sign-v4.svg)](https://crates.io/crates/aws-sign-v4)
 
-Use this crate to generate an AUTHORIZATION header for AWS Signature Version 4 services.
+Use this crate to generate an AUTHORIZATION header for [AWS Signature Version 4](https://docs.aws.amazon.com/general/latest/gr/signing-aws-api-requests.html) services.
 
-## Example
+# Examples
+
+## Example AWS S3 GET request
 Example usage with reqwest:
-
 ```rust
 const S3_ACCESS: &str = "my-access-key";
 const S3_SECRET: &str = "my-secret-key";
@@ -13,7 +14,7 @@ const S3_SECRET: &str = "my-secret-key";
 #[tokio::main]
 async fn main() -> Result<(), reqwest::Error> {
     let datetime = chrono::Utc::now();
-    let url = "https://s3-bucket-url";
+    let url = "https://myHost/s3-bucket-url";
     let mut headers = reqwest::header::HeaderMap::new();
 
     headers.insert(
@@ -24,8 +25,7 @@ async fn main() -> Result<(), reqwest::Error> {
             .parse()
             .unwrap(),
     );
-    headers.insert("X-Amz-Content-Sha256", "UNSIGNED-PAYLOAD".parse().unwrap());
-    headers.insert("host", "my-host".parse().unwrap());
+    headers.insert("host", "myHost".parse().unwrap());
 
     let s = aws_sign_v4::AwsSign::new(
         "GET",
@@ -35,6 +35,8 @@ async fn main() -> Result<(), reqwest::Error> {
         "us-east-1",
         &S3_ACCESS,
         &S3_SECRET,
+        "s3",
+        ""
     );
     let signature = s.sign();
     println!("{:#?}", signature);
@@ -54,3 +56,90 @@ async fn main() -> Result<(), reqwest::Error> {
     Ok(())
 }
 ```
+
+## Example AWS graphql POST request
+Example usage with reqwest:
+```rust
+const S3_ACCESS: &str = "my-access-key";
+const S3_SECRET: &str = "my-secret-key";
+
+#[tokio::main]
+async fn main() -> Result<(), reqwest::Error> {
+    let datetime = chrono::Utc::now();
+    let url = "https://myHost/s3-bucket-url";
+    let mut headers = reqwest::header::HeaderMap::new();
+
+    headers.insert(
+        "X-Amz-Date",
+        datetime
+            .format("%Y%m%dT%H%M%SZ")
+            .to_string()
+            .parse()
+            .unwrap(),
+    );
+    headers.insert("host", "myHost".parse().unwrap());
+
+    let s = aws_sign_v4::AwsSign::new(
+        "POST",
+        url,
+        &datetime,
+        &headers,
+        "us-east-1",
+        &S3_ACCESS,
+        &S3_SECRET,
+        "execute-api",
+        ""
+    );
+    let signature = s.sign();
+    println!("{:#?}", signature);
+    headers.insert(reqwest::header::AUTHORIZATION, signature.parse().unwrap());
+
+    let client = reqwest::Client::new();
+    let res = client
+        .get(url)
+        .headers(headers.to_owned())
+        .body(r#"{"query":"query test_q { mynode { id }} ","variables":{},"operationName":"test_q"}"#)
+        .send()
+        .await?;
+
+    println!("Status: {}", res.status());
+    let body = res.text().await?;
+    println!("Response Body:\n{}", body);
+    Ok(())
+}
+```
+
+# To migrate code from 0.1.x to 0.2.x:
+
+```
+# Before (0.1.1):
+let s = aws_sign_v4::AwsSign::new(
+        "GET",
+        url,
+        &datetime,
+        &headers,
+        "us-east-1",
+        &S3_ACCESS,
+        &S3_SECRET,
+    );
+
+# After (0.2.0):
+let s = aws_sign_v4::AwsSign::new(
+        "GET",
+        url,
+        &datetime,
+        &headers,
+        "us-east-1",
+        &S3_ACCESS,
+        &S3_SECRET,
+        "s3", // <- explicitly add "s3", since 0.1.x only supported "s3"
+        "", // <-- body can be ignored for "s3" service GETs
+    );
+
+```
+
+# References
+
+- [AWS General Reference -> Signing AWS API requests](https://docs.aws.amazon.com/general/latest/gr/signing-aws-api-requests.html)
+- [Amazon Simple Storage Service Api Reference -> Authenticating Requests (AWS Signature Version 4)](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html)
+- [AWS General Reference -> Service endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html) - to look up "service" names and codes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,3 +193,29 @@ pub fn signing_key(
     let signing_tag = ring::hmac::sign(&signing_key, b"aws4_request");
     Ok(signing_tag.as_ref().to_vec())
 }
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sample_canonical_request() {
+        let datetime = chrono::Utc::now();
+        let url: &str = "https://hi.s3.us-east-1.amazonaws.com/Prod/graphql";
+        let map: HeaderMap = HeaderMap::new();
+        let aws_sign = AwsSign::new(
+            "GET",
+            url,
+            &datetime,
+            &map,
+            "us-east-1",
+            "a",
+            "b",
+            "s3",
+            ""
+        );
+        let s = aws_sign.canonical_request();
+        assert_eq!(s, "GET\n/Prod/graphql\n\n\n\n\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,39 @@ where
     access_key: &'a str,
     secret_key: &'a str,
     headers: T,
-    service: &'a str, // todo make this optional
-    body: &'a str, // todo make this optional (default to "")
+
+    /* 
+    service is the <aws-service-code> that can be found in the service-quotas api.
+    
+    For example, use the value `ServiceCode` for this `service` property.
+    Thus, for "Amazon Simple Storage Service (Amazon S3)", you would use value "s3"
+
+    ```
+    > aws service-quotas list-services
+    {
+        "Services": [
+            ...
+            {
+                "ServiceCode": "a4b",
+                "ServiceName": "Alexa for Business"
+            },
+            ...
+            {
+                "ServiceCode": "s3",
+                "ServiceName": "Amazon Simple Storage Service (Amazon S3)"
+            },
+            ...
+    ```
+    This is not absolute, so you might need to poke around at the service you're interesed in.
+    See:
+    [AWS General Reference -> Service endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html) - to look up "service" names and codes
+
+    added in 0.2.0
+    */
+    service: &'a str,
+
+    /// body, such as in an http POST
+    body: &'a str,
 }
 
 impl<'a> AwsSign<'a, HashMap<String, String>> {
@@ -158,7 +189,6 @@ pub fn scope_string(datetime: &DateTime<Utc>, region: &str, service: &str) -> St
     )
 }
 
-// todo service must be optional for semver
 pub fn string_to_sign(datetime: &DateTime<Utc>, region: &str, canonical_req: &str, service: &str) -> String {
     let hash = ring::digest::digest(&ring::digest::SHA256, canonical_req.as_bytes());
     format!(


### PR DESCRIPTION
Hello @psnszsn,

I hope this finds you well. Thank you for open-sourcing this lib!

I searched around for something I could use for making a graphql call and your lib was the one that provided the most straight-forward thing without needing too many deps and some assumptions of context.

I added ability to support a POST body and use other services besides `s3` (in my case, I needed `execute-api`) & thought I'd send it along to you, if you'd like a contribution to your project. This PR should address Issue https://github.com/psnszsn/aws-sign-v4/issues/1 in this repo.

You can see the `CHANGELOG.md` in this PR for an overview description of changes. Copy-and-pasted here for your convenience:

> ### Added 
>
> - Support for sigv4 `service` attributes beyond "s3" (e.g. "execute-api") in `AwsSign` struct
> - Support for "body" attribute beyond "s3" in `AwsSign` struct
> - More documentation
> 
> ### Changed
> 
> - Upgrage Rust Edition to 2021
> - Upgrade dependencies
> - License from MIT to BSD 2-Clause (like MIT, but "don't blame me if things go wrong")
> 

No worries, if you're not accepting PRs. Just let me know & I'll just rename the project in my fork instead (will continue to attribute you in any case, of course). If you are open to contributions, I was thinking of a v0.3.0 to update the interface to make some args optional (e.g. "body"), perhaps add a builder interface, and/or some light typing, and tweaks like that.

In any case, I know this project hasn't been active in 3 years, but I still appreciate your work! Thank you for saving me a bit of effort!

Ken