### PR TITLE
Add example to publish to SNS topic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,62 @@ async fn main() -> Result<(), reqwest::Error> {
 }
 ```
 
+## Example AWS SNS publish request
+
+Example usage with reqwest:
+
+```rust
+const S3_ACCESS: &str = "my-access-key";
+const S3_SECRET: &str = "my-secret-key";
+const S3_TOPIC_ARN: &str = "arn:aws:sns:eu-west-1:xxx:xxx";
+const S3_REGION: &str = "eu-west-1";
+
+#[tokio::main]
+async fn main() {
+    let hostname = format!("sns.{}.amazonaws.com", S3_REGION);
+    let url = format!("https://{}/", hostname);
+    let ts = chrono::Utc::now();
+
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert("host", hostname.parse().unwrap());
+    headers.insert(
+        "X-Amz-Date",
+        ts.format("%Y%m%dT%H%M%SZ").to_string().parse().unwrap(),
+    );
+    headers.insert(
+        reqwest::header::CONTENT_TYPE,
+        "application/x-www-form-urlencoded".parse().unwrap(),
+    );
+
+    let body = [
+        ("Action", "Publish"),
+        ("TopicArn", S3_TOPIC_ARN),
+        ("MessageAttributes.entry.1.Name", "AttributeExample"),
+        ("MessageAttributes.entry.1.Value.DataType", "String"),
+        ("MessageAttributes.entry.1.Value.StringValue", "AttributeExampleValue"),
+        ("Message", "Hello world!"),
+    ];
+    let body = serde_urlencoded::to_string(body).unwrap();
+
+    let s = aws_sign_v4::AwsSign::new(
+        "POST", &url, &ts, &headers, &S3_REGION, &S3_ACCESS, &S3_SECRET, "sns", &body,
+    )
+    .sign();
+
+    headers.insert(reqwest::header::AUTHORIZATION, s.parse().unwrap());
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(url)
+        .headers(headers)
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    res.error_for_status().unwrap();
+}
+```
+
 # To migrate code from 0.1.x to 0.2.x:
 
 ```


### PR DESCRIPTION
Hello @psnszsn, thank you so much for implementing this crate. Currently I'm using the `aws-sdk-sns` crate to publish to a SNS topic. The `aws-sdk-sns` crate works well, but it is pulling in quite a few dependencies. Your crate will be very helpful to reduce the amount of dependencies :+1: 

I did a quick test, and your crate works well when publishing to a SNS topic. I thought some example code would be helpful to others as well.