### PR TITLE
Update dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-sign-v4"
-version = "0.2.0"
+version = "0.3.0"
 description = "Generate AWS Signature 4 headers easily"
 repository = "https://github.com/psnszsn/aws-sign-v4"
 keywords = ["AWS", "Signature"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono = "0.4.23"
-url = "2.3.1"
+chrono = "0.4.27"
+url = "2.5.0"
 hex = "0.4.3"
-ring = "0.16.20"
-http = "0.2.8"
-sha256 = "1.1.1"
+ring = "0.17.8"
+http = "1.1.0"
+sha256 = "1.5.0"


### PR DESCRIPTION
This updates the dependencies to their latest versions. This is especially useful when using in combination with the latest `reqwest` crate, which has moved to `http=^1`.

Once this has been merged, would you mind creating a new release of this crate?