### PR TITLE
Fix uri encode for bytes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,11 +158,10 @@ pub fn uri_encode(string: &str, encode_slash: bool) -> String {
             '/' if encode_slash => result.push_str("%2F"),
             '/' if !encode_slash => result.push('/'),
             _ => {
-                result.push('%');
-                result.push_str(
+                                result.push_str(
                     &format!("{}", c)
                         .bytes()
-                        .map(|b| format!("{:02X}", b))
+                        .map(|b| format!("%{:02X}", b))
                         .collect::<String>(),
                 );
             }


### PR DESCRIPTION
I had an issue when trying to get a file on my S3, the file wasn't found because it had the char `é`.

For this char, the serialization was: `%C3A9`, but the server expected `%C3%A9`.

<details> 
  <summary>Details :</summary>
I am using Scaleway S3 buckets.
This is what the download function looks like:
```rs
    let datetime = chrono::Utc::now();
    let url = &format!(
        "https://{}/{}",
        *constants::s3::ADDRESS,
        aws_sign_v4::uri_encode(remote_filename, false)
    );
    let mut headers = reqwest::header::HeaderMap::new();

    headers.insert(
        "X-Amz-Date",
        datetime.format("%Y%m%dT%H%M%SZ").to_string().parse()?,
    );
    headers.insert("host", constants::s3::ADDRESS.parse()?);
    headers.insert(
        "X-Amz-Content-Sha256",
        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".parse()?,
    );

    let signature = aws_sign_v4::AwsSign::new(
        "GET",
        url,
        &datetime,
        &headers,
        "fr-par",
        &constants::s3::ACCESS,
        &constants::s3::SECRET,
        "s3",
        "",
    )
    .sign();
    headers.insert(reqwest::header::AUTHORIZATION, signature.parse()?);

    let client = reqwest::Client::new();
    let res = client
        .get(url)
        .headers(headers.to_owned())
        .body("")
        .send()
        .await?;

    if res.status() != 200 {
        bail!("unable to download file: {}", res.text().await?)
    }
    res.bytes()
        .await
        .map(|b| b.to_vec())
        .context("reading bytes of response body")
```
</details>

